### PR TITLE
In process reload support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,4 +16,5 @@ bytes = "1.2.1"
 http = "0.2.8"
 http-body = "0.4.5"
 pin-project-lite = "0.2.9"
+tokio = { version = "1.21.2", features = ["sync", "rt"] }
 tower = "0.4.13"

--- a/README.md
+++ b/README.md
@@ -46,6 +46,14 @@ More examples can be found on GitHub under [examples].
 [tower]: https://docs.rs/tower
 [examples]: https://github.com/leotaku/tower-livereload/tree/master/examples
 
+## Manual reload
+
+With the [`Reloader`] utility, it is possible to reload your web browser
+entirely using hooks from Rust code. See this [example] on GitHub for
+pointers on how to implement a self-contained live-reloading static server.
+
+[example]: https://github.com/leotaku/tower-livereload/blob/master/examples/axum-in-process/
+
 ## Ecosystem compatibility
 
 `tower-livereload` has been built from the ground up to provide the highest
@@ -55,9 +63,6 @@ The provided middleware uses the [`http`] and [`http_body`] crates as its
 HTTP abstractions. That means it is compatible with any library or framework
 that also uses those crates, such as [`hyper`], [`axum`], [`tonic`], and
 [`warp`].
-
-Moreover, we do not depend on any async runtime, keeping your dependency
-graph small and simplifying debugging.
 
 [`http`]: https://docs.rs/http
 [`http_body`]: https://docs.rs/http_body
@@ -86,6 +91,7 @@ applied before your compression middleware.
 <!-- Override internal links from README generation: -->
 
 [`LiveReload`]: https://docs.rs/tower-livereload/latest/tower_livereload/struct.LiveReload.html
+[`Reloader`]: https://docs.rs/tower-livereload/latest/tower_livereload/struct.Reloader.html
 
 ## License
 

--- a/README.tpl
+++ b/README.tpl
@@ -20,6 +20,7 @@
 <!-- Override internal links from README generation: -->
 
 [`LiveReload`]: https://docs.rs/tower-livereload/latest/tower_livereload/struct.LiveReload.html
+[`Reloader`]: https://docs.rs/tower-livereload/latest/tower_livereload/struct.Reloader.html
 
 ## License
 

--- a/assets/polling.html
+++ b/assets/polling.html
@@ -1,12 +1,12 @@
 <script type="module">
   const retry = (it) =>
-    fetch(it)
+    fetch(it, {{ cache: "no-store" }})
       .then(() => console.log("[tower-livereload] reload..."))
       .then(() => window.location.reload())
       .catch(() => setTimeout(() => retry(it), 1000));
 
   const main = async () =>
-    fetch("{long_poll}")
+    fetch("{long_poll}", {{ cache: "no-store" }})
       .then((it) => it.text().catch(() => null))
       .catch(() => null)
       .then(() => console.log("[tower-livereload] disconnected..."))

--- a/examples/axum-in-process/Cargo.toml
+++ b/examples/axum-in-process/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "axum-in-process"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+axum = "0.5.15"
+notify = "5.0.0"
+tokio = { version = "1.21.1", features = ["macros", "rt-multi-thread", "sync", "rt"] }
+tower = "0.4.13"
+tower-http = { version = "0.3.4", features = ["fs"] }
+tower-livereload = { path = "../.." }

--- a/examples/axum-in-process/assets/index.html
+++ b/examples/axum-in-process/assets/index.html
@@ -1,0 +1,13 @@
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Example Page</title>
+  </head>
+  <body>
+    <h1>Example!!!</h1>
+    <div>
+      Lorem ipsum dolor sit amet
+    </div>
+  </body>
+</html>

--- a/examples/axum-in-process/assets/index.html
+++ b/examples/axum-in-process/assets/index.html
@@ -5,7 +5,7 @@
     <title>Example Page</title>
   </head>
   <body>
-    <h1>Example!!!</h1>
+    <h1>Example</h1>
     <div>
       Lorem ipsum dolor sit amet
     </div>

--- a/examples/axum-in-process/src/main.rs
+++ b/examples/axum-in-process/src/main.rs
@@ -1,0 +1,32 @@
+use axum::{body::Body, http, routing::get_service, Router};
+use notify::Watcher;
+use std::path::Path;
+use tower_http::services::ServeDir;
+use tower_livereload::LiveReloadLayer;
+
+fn serve_dir(path: &str) -> axum::routing::MethodRouter<Body> {
+    get_service(ServeDir::new(path)).handle_error(|error| async move {
+        (
+            http::StatusCode::INTERNAL_SERVER_ERROR,
+            format!("Unhandled internal error: {}", error),
+        )
+    })
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let livereload = LiveReloadLayer::new();
+    let reloader = livereload.reloader();
+    let app = Router::<Body>::new()
+        .nest("/", serve_dir("assets"))
+        .layer(livereload);
+
+    let mut watcher = notify::recommended_watcher(move |_| reloader.reload())?;
+    watcher.watch(Path::new("assets"), notify::RecursiveMode::Recursive)?;
+
+    axum::Server::bind(&"0.0.0.0:3030".parse()?)
+        .serve(app.into_make_service())
+        .await?;
+
+    Ok(())
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,6 +29,14 @@
 //! [tower]: https://docs.rs/tower
 //! [examples]: https://github.com/leotaku/tower-livereload/tree/master/examples
 //!
+//! # Manual reload
+//!
+//! With the [`Reloader`] utility, it is possible to reload your web browser
+//! entirely using hooks from Rust code. See this [example] on GitHub for
+//! pointers on how to implement a self-contained live-reloading static server.
+//!
+//! [example]: https://github.com/leotaku/tower-livereload/blob/master/examples/axum-in-process/
+//!
 //! # Ecosystem compatibility
 //!
 //! `tower-livereload` has been built from the ground up to provide the highest
@@ -38,9 +46,6 @@
 //! HTTP abstractions. That means it is compatible with any library or framework
 //! that also uses those crates, such as [`hyper`], [`axum`], [`tonic`], and
 //! [`warp`].
-//!
-//! Moreover, we do not depend on any async runtime, keeping your dependency
-//! graph small and simplifying debugging.
 //!
 //! [`http`]: https://docs.rs/http
 //! [`http_body`]: https://docs.rs/http_body

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -84,7 +84,7 @@ use tokio::sync::broadcast::{Receiver, Sender};
 use tower::{Layer, Service};
 
 /// Utility to send reload requests to clients.
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct Reloader {
     sender: Sender<()>,
 }

--- a/src/long_poll.rs
+++ b/src/long_poll.rs
@@ -1,13 +1,15 @@
-use std::{convert::Infallible, future::Future, pin::Pin, task::Poll};
+use std::{convert::Infallible, task::Poll};
 use tokio::sync::broadcast::Receiver;
 
 pub struct LongPollBody {
-    receiver: Receiver<()>,
+    receiver: Option<Receiver<()>>,
 }
 
 impl LongPollBody {
     pub fn new(receiver: Receiver<()>) -> Self {
-        LongPollBody { receiver }
+        LongPollBody {
+            receiver: Some(receiver),
+        }
     }
 }
 
@@ -19,22 +21,16 @@ impl http_body::Body for LongPollBody {
         mut self: std::pin::Pin<&mut Self>,
         cx: &mut std::task::Context<'_>,
     ) -> Poll<Option<Result<Self::Data, Self::Error>>> {
-        let polled = {
-            let mut boxed = Box::pin(self.receiver.recv());
-            Pin::new(&mut boxed).poll(cx)
-        };
-
-        match polled {
-            Poll::Ready(Ok(_)) => Poll::Ready(None),
-            Poll::Ready(Err(_)) | Poll::Pending => {
+        match self.receiver.take() {
+            Some(mut receiver) => {
                 let waker = cx.waker().clone();
-                let mut receiver = self.receiver.resubscribe();
                 tokio::spawn(async move {
                     receiver.recv().await.ok();
                     waker.wake();
                 });
                 Poll::Pending
             }
+            None => Poll::Ready(None),
         }
     }
 

--- a/src/long_poll.rs
+++ b/src/long_poll.rs
@@ -1,10 +1,13 @@
-use std::{convert::Infallible, task::Poll};
+use std::{convert::Infallible, future::Future, pin::Pin, task::Poll};
+use tokio::sync::broadcast::Receiver;
 
-pub struct LongPollBody(());
+pub struct LongPollBody {
+    receiver: Receiver<()>,
+}
 
 impl LongPollBody {
-    pub fn new() -> Self {
-        LongPollBody(())
+    pub fn new(receiver: Receiver<()>) -> Self {
+        LongPollBody { receiver }
     }
 }
 
@@ -13,10 +16,26 @@ impl http_body::Body for LongPollBody {
     type Error = Infallible;
 
     fn poll_data(
-        self: std::pin::Pin<&mut Self>,
-        _cx: &mut std::task::Context<'_>,
+        mut self: std::pin::Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
     ) -> Poll<Option<Result<Self::Data, Self::Error>>> {
-        Poll::Pending
+        let polled = {
+            let mut boxed = Box::pin(self.receiver.recv());
+            Pin::new(&mut boxed).poll(cx)
+        };
+
+        match polled {
+            Poll::Ready(Ok(_)) => Poll::Ready(None),
+            Poll::Ready(Err(_)) | Poll::Pending => {
+                let waker = cx.waker().clone();
+                let mut receiver = self.receiver.resubscribe();
+                tokio::spawn(async move {
+                    receiver.recv().await.ok();
+                    waker.wake();
+                });
+                Poll::Pending
+            }
+        }
     }
 
     fn poll_trailers(


### PR DESCRIPTION
Someone asked for this per e-mail, and it seems like a good idea.

Current open problems:

+ [x] Seemingly makes it impossible to stay runtime-agnostic
  + The only way to reliably wait on events e.g. on a channel seems to be using a `runtime::spawn` call. Also, we are currently using tokio broadcast channels. Maybe we could switch to smol?
  + **Resolved:** I've looked through the tokio discord and while there is no technical reason that means tower could not support other runtimes, it currently only officially supports tokio. The tower-http crate also depends on tokio, so I see no reason to stay runtime-agnostic at this time. If anyone reading this is interested in using this crate without the tokio runtime, please contact me.
+ [x] Decide if this should be feature-gated behind a default feature
  + Could make it possible for the crate to stay fully runtime-agnostic for people who do not need in-process reloading
  + **Resolved:** See first problem, runtime-agnosticism is no longer a goal. Feature gates can always be added later.
+ [x] Decide if every `LiveReload` should have a reloader
  + Probably fine, but bad if we want to feature-gate
  + **Resolved:** For now, every `LiveReload` has a reloader.