### PR TITLE
Implement configurable request and response predicates

### DIFF
--- a/src/inject.rs
+++ b/src/inject.rs
@@ -51,7 +51,7 @@ where
         InjectResponseFuture {
             inner: self.service.call(request),
             data: should_inject.then(|| self.data.clone()),
-            predicate: self.res_predicate.clone(),
+            predicate: self.res_predicate,
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -82,7 +82,7 @@
 mod inject;
 mod long_poll;
 mod overlay;
-mod predicate;
+pub mod predicate;
 mod ready_polyfill;
 
 use std::convert::Infallible;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -91,7 +91,7 @@ use http::{header, Request, Response, StatusCode};
 use inject::InjectService;
 use long_poll::LongPollBody;
 use overlay::OverlayService;
-use predicate::{AlwaysPredicate, ContentTypeStartsWithPredicate, Predicate};
+use predicate::{Always, ContentTypeStartsWith, Predicate};
 use tokio::sync::broadcast::Sender;
 use tower::{Layer, Service};
 
@@ -129,8 +129,8 @@ impl Default for Reloader {
 /// Layer to apply [`LiveReload`] middleware.
 #[derive(Clone, Debug)]
 pub struct LiveReloadLayer<
-    ReqPred = AlwaysPredicate,
-    ResPred = ContentTypeStartsWithPredicate<&'static str>,
+    ReqPred = Always,
+    ResPred = ContentTypeStartsWith<&'static str>,
 > {
     custom_prefix: Option<String>,
     reloader: Reloader,
@@ -148,8 +148,8 @@ impl LiveReloadLayer {
         Self {
             custom_prefix: None,
             reloader: Reloader::new(),
-            req_predicate: AlwaysPredicate,
-            res_predicate: ContentTypeStartsWithPredicate::new("text/html"),
+            req_predicate: Always,
+            res_predicate: ContentTypeStartsWith::new("text/html"),
         }
     }
 
@@ -258,8 +258,8 @@ type InnerService<S, ReqPred, ResPred> = OverlayService<
 #[derive(Clone, Debug)]
 pub struct LiveReload<
     S,
-    ReqPred = AlwaysPredicate,
-    ResPred = ContentTypeStartsWithPredicate<&'static str>,
+    ReqPred = Always,
+    ResPred = ContentTypeStartsWith<&'static str>,
 > {
     service: InnerService<S, ReqPred, ResPred>,
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -106,7 +106,7 @@ pub struct Reloader {
 impl Reloader {
     /// Create a new [`Reloader`].
     ///
-    /// This can be manually passed to the [`LiveReload`] constructors, but in
+    /// This can be manually passed to the [`LiveReload`] constructor, but in
     /// most cases the [`LiveReloadLayer`] and [`LiveReloadLayer::reloader`]
     /// utilities are preferred.
     pub fn new() -> Self {
@@ -177,7 +177,7 @@ impl<ReqPred, ResPred> LiveReloadLayer<ReqPred, ResPred> {
     /// injected with live-reload logic.
     ///
     /// Note that this predicate is appled in addition to the default response
-    /// predicates, which make sure that only HTML responses are injected.
+    /// predicate, which makes sure that only HTML responses are injected.
     ///
     /// Also see [`predicate`] for pre-defined predicates and
     /// [`predicate::Predicate`] for how to implement your own predicates.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -181,7 +181,7 @@ impl<ReqPred, ResPred> LiveReloadLayer<ReqPred, ResPred> {
     ///
     /// Also see [`predicate`] for pre-defined predicates and
     /// [`predicate::Predicate`] for how to implement your own predicates.
-    pub fn request_predicate<R, P: Predicate<R>>(
+    pub fn request_predicate<Body, P: Predicate<Request<Body>>>(
         self,
         predicate: P,
     ) -> LiveReloadLayer<P, ResPred> {
@@ -207,7 +207,7 @@ impl<ReqPred, ResPred> LiveReloadLayer<ReqPred, ResPred> {
     ///
     /// [`Content-Length`]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Length
     /// [`Content-Encoding`]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Encoding
-    pub fn response_predicate<R, P: Predicate<R>>(
+    pub fn response_predicate<Body, P: Predicate<Response<Body>>>(
         self,
         predicate: P,
     ) -> LiveReloadLayer<ReqPred, P> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -242,7 +242,7 @@ impl<S, ReqPred: Copy, ResPred: Copy> Layer<S> for LiveReloadLayer<ReqPred, ResP
             self.res_predicate,
             self.custom_prefix
                 .as_ref()
-                .map(|it| it.clone())
+                .cloned()
                 .unwrap_or_else(|| DEFAULT_PREFIX.to_owned()),
         )
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -149,6 +149,10 @@ impl LiveReloadLayer {
     }
 
     /// Create a new [`LiveReloadLayer`] with a custom prefix.
+    #[deprecated(
+        since = "0.8.0",
+        note = "please use `LiveReloadLayer::new` and `custom_prefix` instead"
+    )]
     pub fn with_custom_prefix<P: Into<String>>(prefix: P) -> Self {
         Self {
             custom_prefix: Some(prefix.into()),
@@ -159,6 +163,15 @@ impl LiveReloadLayer {
 }
 
 impl<ReqPred> LiveReloadLayer<ReqPred> {
+    /// Set a custom prefix for internal routes for the given
+    /// [`LiveReloadLayer`].
+    pub fn custom_prefix<P: Into<String>>(self, prefix: P) -> Self {
+        Self {
+            custom_prefix: Some(prefix.into()),
+            ..self
+        }
+    }
+
     /// Set a custom predicate for requests that should have their
     /// response HTML injected with live-reload logic.
     ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -172,16 +172,15 @@ impl<ReqPred> LiveReloadLayer<ReqPred> {
         }
     }
 
-    /// Set a custom predicate for requests that should have their
-    /// response HTML injected with live-reload logic.
+    /// Set a custom predicate for requests that should have their response HTML
+    /// injected with live-reload logic.
     ///
-    /// Note that these predicates are appled in addition to the
-    /// default response predicates, which make sure that only HTML
-    /// responses are injected.
+    /// Note that these predicates are appled in addition to the default
+    /// response predicates, which make sure that only HTML responses are
+    /// injected.
     ///
     /// Also see [`predicate`] for pre-defined predicates and
-    /// [`predicate::Predicate`] for how to implement your own
-    /// predicates.
+    /// [`predicate::Predicate`] for how to implement your own predicates.
     pub fn request_predicate<R, P: Predicate<R>>(self, predicate: P) -> LiveReloadLayer<P> {
         LiveReloadLayer {
             custom_prefix: self.custom_prefix,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -231,8 +231,8 @@ impl Default for LiveReloadLayer {
     }
 }
 
-impl<S, ReqPred: Clone> Layer<S> for LiveReloadLayer<ReqPred> {
-    type Service = LiveReload<S, ReqPred>;
+impl<S, ReqPred: Clone, ResPred: Clone> Layer<S> for LiveReloadLayer<ReqPred, ResPred> {
+    type Service = LiveReload<S, ReqPred, ResPred>;
 
     fn layer(&self, inner: S) -> Self::Service {
         LiveReload::new(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -231,15 +231,15 @@ impl Default for LiveReloadLayer {
     }
 }
 
-impl<S, ReqPred: Clone, ResPred: Clone> Layer<S> for LiveReloadLayer<ReqPred, ResPred> {
+impl<S, ReqPred: Copy, ResPred: Copy> Layer<S> for LiveReloadLayer<ReqPred, ResPred> {
     type Service = LiveReload<S, ReqPred, ResPred>;
 
     fn layer(&self, inner: S) -> Self::Service {
         LiveReload::new(
             inner,
             self.reloader.clone(),
-            self.req_predicate.clone(),
-            self.res_predicate.clone(),
+            self.req_predicate,
+            self.res_predicate,
             self.custom_prefix
                 .as_ref()
                 .map(|it| it.clone())

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -159,12 +159,7 @@ impl LiveReloadLayer {
         note = "please use `LiveReloadLayer::new` and `custom_prefix` instead"
     )]
     pub fn with_custom_prefix<P: Into<String>>(prefix: P) -> Self {
-        Self {
-            custom_prefix: Some(prefix.into()),
-            reloader: Reloader::new(),
-            req_predicate: AlwaysPredicate,
-            res_predicate: ContentTypeStartsWithPredicate::new("text/html"),
-        }
+        Self::new().custom_prefix(prefix)
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -95,6 +95,8 @@ use predicate::ContentTypeStartsWithPredicate;
 use tokio::sync::broadcast::Sender;
 use tower::{Layer, Service};
 
+const DEFAULT_PREFIX: &str = "/tower-livereload/long-name-to-avoid-collisions";
+
 /// Utility to send reload requests to clients.
 #[derive(Clone, Debug)]
 pub struct Reloader {
@@ -174,7 +176,7 @@ impl<S> Layer<S> for LiveReloadLayer {
             self.custom_prefix
                 .as_ref()
                 .map(|it| it.clone())
-                .unwrap_or_else(|| "/tower-livereload/long-name-to-avoid-collisions".to_owned()),
+                .unwrap_or_else(|| DEFAULT_PREFIX.to_owned()),
         )
     }
 }

--- a/src/predicate.rs
+++ b/src/predicate.rs
@@ -22,3 +22,21 @@ impl<T, Patt: AsRef<str> + Copy> Predicate<Response<T>> for ContentTypeStartsWit
             .unwrap_or(false)
     }
 }
+
+#[derive(Copy, Clone, Debug)]
+pub struct AlwaysPredicate;
+
+impl<T> Predicate<T> for AlwaysPredicate {
+    fn check<'a>(&mut self, _request: &'a T) -> bool {
+        true
+    }
+}
+
+impl<T, F> Predicate<T> for F
+where
+    F: Fn(&T) -> bool + Clone,
+{
+    fn check<'a>(&mut self, request: &'a T) -> bool {
+        (self)(request)
+    }
+}

--- a/src/predicate.rs
+++ b/src/predicate.rs
@@ -6,7 +6,7 @@
 use http::{header, Response};
 
 /// Trait for predicates that check if a value matches them.
-pub trait Predicate<T>: Clone {
+pub trait Predicate<T>: Copy {
     /// Check if the predicate matches the given value.
     fn check(&mut self, thing: &T) -> bool;
 }
@@ -46,7 +46,7 @@ impl<T> Predicate<T> for AlwaysPredicate {
 
 impl<T, F> Predicate<T> for F
 where
-    F: Fn(&T) -> bool + Clone,
+    F: Fn(&T) -> bool + Copy,
 {
     fn check<'a>(&mut self, request: &'a T) -> bool {
         (self)(request)

--- a/src/predicate.rs
+++ b/src/predicate.rs
@@ -15,16 +15,16 @@ pub trait Predicate<T>: Copy {
 ///
 /// [`Content-Type`]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Type
 #[derive(Copy, Clone, Debug)]
-pub struct ContentTypeStartsWithPredicate<Patt>(Patt);
+pub struct ContentTypeStartsWith<Patt>(Patt);
 
-impl<Patt: AsRef<str> + Copy> ContentTypeStartsWithPredicate<Patt> {
-    /// Create a new [`ContentTypeStartsWithPredicate`] predicate.
+impl<Patt: AsRef<str> + Copy> ContentTypeStartsWith<Patt> {
+    /// Create a new [`ContentTypeStartsWith`] predicate.
     pub fn new(pattern: Patt) -> Self {
-        ContentTypeStartsWithPredicate(pattern)
+        ContentTypeStartsWith(pattern)
     }
 }
 
-impl<T, Patt: AsRef<str> + Copy> Predicate<Response<T>> for ContentTypeStartsWithPredicate<Patt> {
+impl<T, Patt: AsRef<str> + Copy> Predicate<Response<T>> for ContentTypeStartsWith<Patt> {
     fn check(&mut self, response: &Response<T>) -> bool {
         response
             .headers()
@@ -36,10 +36,10 @@ impl<T, Patt: AsRef<str> + Copy> Predicate<Response<T>> for ContentTypeStartsWit
 
 /// A predicate that matches any request or response.
 #[derive(Copy, Clone, Debug)]
-pub struct AlwaysPredicate;
+pub struct Always;
 
-impl<T> Predicate<T> for AlwaysPredicate {
-    fn check(&mut self, _request: &T) -> bool {
+impl<T> Predicate<T> for Always {
+    fn check(&mut self, _thing: &T) -> bool {
         true
     }
 }
@@ -48,7 +48,7 @@ impl<T, F> Predicate<T> for F
 where
     F: Fn(&T) -> bool + Copy,
 {
-    fn check(&mut self, request: &T) -> bool {
-        (self)(request)
+    fn check(&mut self, thing: &T) -> bool {
+        (self)(thing)
     }
 }

--- a/src/predicate.rs
+++ b/src/predicate.rs
@@ -39,7 +39,7 @@ impl<T, Patt: AsRef<str> + Copy> Predicate<Response<T>> for ContentTypeStartsWit
 pub struct AlwaysPredicate;
 
 impl<T> Predicate<T> for AlwaysPredicate {
-    fn check<'a>(&mut self, _request: &'a T) -> bool {
+    fn check(&mut self, _request: &T) -> bool {
         true
     }
 }
@@ -48,7 +48,7 @@ impl<T, F> Predicate<T> for F
 where
     F: Fn(&T) -> bool + Copy,
 {
-    fn check<'a>(&mut self, request: &'a T) -> bool {
+    fn check(&mut self, request: &T) -> bool {
         (self)(request)
     }
 }

--- a/src/predicate.rs
+++ b/src/predicate.rs
@@ -1,13 +1,24 @@
+//! Predicates for matching HTTP responses and requests.
+//!
+//! Note that in addition to the predicates exported by this module,
+//! [`Predicate`] is also implemented for `Fn(&T) -> bool + Copy`,
+//! which is useful for quickly getting an arbitrary predicate.
 use http::{header, Response};
 
+/// Trait for predicates that check if a value matches them.
 pub trait Predicate<T>: Clone {
+    /// Check if the predicate matches the given value.
     fn check(&mut self, thing: &T) -> bool;
 }
 
+/// A predicate that matches based on [`Content-Type`] header.
+///
+/// [`Content-Type`]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Type
 #[derive(Copy, Clone, Debug)]
 pub struct ContentTypeStartsWithPredicate<Patt>(Patt);
 
 impl<Patt: AsRef<str> + Copy> ContentTypeStartsWithPredicate<Patt> {
+    /// Create a new [`ContentTypeStartsWithPredicate`] predicate.
     pub fn new(pattern: Patt) -> Self {
         ContentTypeStartsWithPredicate(pattern)
     }
@@ -23,6 +34,7 @@ impl<T, Patt: AsRef<str> + Copy> Predicate<Response<T>> for ContentTypeStartsWit
     }
 }
 
+/// A predicate that matches any request or response.
 #[derive(Copy, Clone, Debug)]
 pub struct AlwaysPredicate;
 


### PR DESCRIPTION
Also, this necessitates a non backwards-compatible change within the `LiveReload` initializers. This should be fine and also allows for the removal of some duplicate code.

Here is an example of how one could apply a custom request predicate. Response predicates are applied the same way but using the `response_predicate` function on `LiveReloadLayer`.

``` rust
use axum::{http::Request, response::Html, routing::get, Router};
use tower_livereload::LiveReloadLayer;

fn not_htmx_predicate<Body>(req: &Request<Body>) -> bool {
    !req.headers().contains_key("hx-request")
}

#[tokio::main]
async fn main() -> Result<(), Box<dyn std::error::Error>> {
    let app = Router::new()
        .route("/", get(|| async { Html("<h1>Wow, such webdev</h1>") }))
        .layer(LiveReloadLayer::new().request_predicate(not_htmx_predicate));

    axum::Server::bind(&"0.0.0.0:3030".parse()?)
        .serve(app.into_make_service())
        .await?;

    Ok(())
}
```

@wrapperup you can test if this code works for your use-case.
Any feedback is appreciated!

Would close #2