### PR TITLE
Customizable reload interval

### DIFF
--- a/assets/polling.html
+++ b/assets/polling.html
@@ -9,7 +9,7 @@
     fetch(it, {{ cache: "no-store" }})
       .then(() => console.log("[tower-livereload] reload..."))
       .then(() => window.location.reload())
-      .catch(() => setTimeout(() => retry(it), 1000));
+      .catch(() => setTimeout(() => retry(it), {reload_interval}));
 
   const main = async () =>
     fetch("{long_poll}", {{ cache: "no-store" }})

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -249,11 +249,11 @@ impl<S, ReqPred: Copy, ResPred: Copy> Layer<S> for LiveReloadLayer<ReqPred, ResP
             self.reloader.clone(),
             self.req_predicate,
             self.res_predicate,
+            self.reload_interval,
             self.custom_prefix
                 .as_ref()
                 .cloned()
                 .unwrap_or_else(|| DEFAULT_PREFIX.to_owned()),
-            self.reload_interval,
         )
     }
 }
@@ -277,8 +277,8 @@ impl<S, ReqPred, ResPred> LiveReload<S, ReqPred, ResPred> {
         reloader: Reloader,
         req_predicate: ReqPred,
         res_predicate: ResPred,
-        prefix: P,
         reload_interval: Duration,
+        prefix: P,
     ) -> Self {
         let prefix = prefix.into();
         let long_poll_path = format!("{}/long-poll", prefix);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -287,9 +287,9 @@ impl<S, ReqPred, ResPred> LiveReload<S, ReqPred, ResPred> {
             service,
             format!(
                 include_str!("../assets/polling.html"),
-                reload_interval = reload_interval.as_millis(),
                 long_poll = long_poll_path,
                 back_up = back_up_path,
+                reload_interval = reload_interval.as_millis(),
             )
             .into(),
             req_predicate,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -220,7 +220,7 @@ impl<ReqPred, ResPred> LiveReloadLayer<ReqPred, ResPred> {
         }
     }
 
-    /// Set a custom interval for the live-reload logic.
+    /// Set a custom retry interval for the live-reload logic.
     pub fn reload_interval(self, interval: Duration) -> Self {
         Self {
             reload_interval: interval,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -220,17 +220,17 @@ impl<ReqPred, ResPred> LiveReloadLayer<ReqPred, ResPred> {
         }
     }
 
-    /// Return a manual [`Reloader`] trigger for the given [`LiveReloadLayer`].
-    pub fn reloader(&self) -> Reloader {
-        self.reloader.clone()
-    }
-
     /// Set a custom interval for the live-reload logic.
     pub fn reload_interval(self, interval: Duration) -> Self {
         Self {
             reload_interval: interval,
             ..self
         }
+    }
+
+    /// Return a manual [`Reloader`] trigger for the given [`LiveReloadLayer`].
+    pub fn reloader(&self) -> Reloader {
+        self.reloader.clone()
     }
 }
 


### PR DESCRIPTION
This allows you to define the interval for the live-reload check in the script. Sometimes it felt sluggish to iterate, since you would be caught in a long end of the 1-second cycle.

For example, it can be customized like so:
```rust
LiveReloadLayer::new().reload_interval(Duration::from_millis(100))
```