### PR TITLE
Add timeout for retries to prevent retry request from hanging

### DIFF
--- a/assets/polling.html
+++ b/assets/polling.html
@@ -7,7 +7,7 @@
 
   const retry = (url) => {{
     const controller = new AbortController();
-    const timeoutId = setTimeout(() => controller.abort(), 500);
+    setTimeout(() => controller.abort(), 500);
     fetch(url, {{ cache: "no-store", signal: controller.signal }})
       .then(() => console.log("[tower-livereload] reload..."))
       .then(() => window.location.reload())

--- a/assets/polling.html
+++ b/assets/polling.html
@@ -5,11 +5,14 @@
     unloaded = true;
   }});
 
-  const retry = (url) =>
-    fetch(url, {{ cache: "no-store" }})
+  const retry = (url) => {{
+    const controller = new AbortController();
+    const timeoutId = setTimeout(() => controller.abort(), 500);
+    fetch(url, {{ cache: "no-store", signal: controller.signal }})
       .then(() => console.log("[tower-livereload] reload..."))
       .then(() => window.location.reload())
-      .catch(() => setTimeout(() => retry(url), {reload_interval}));
+      .catch(() => setTimeout(() => retry(url), {reload_interval}))
+  }};
 
   const main = () =>
     fetch("{long_poll}", {{ cache: "no-store" }})


### PR DESCRIPTION
When using from [devcontainers](https://code.visualstudio.com/docs/devcontainers/containers) during cargo recompilation and a small time after that the forwarded port will not be reachable leading to the retry request to hang indefinitely. This pull request times out the retry so it retries again to reload the page. Hopefully reasonable 😅