### PR TITLE
fix: introduce timeout to abort back_up request

### DIFF
--- a/assets/polling.html
+++ b/assets/polling.html
@@ -5,11 +5,19 @@
     unloaded = true;
   }});
 
-  const retry = (url) =>
-    fetch(url, {{ cache: "no-store" }})
+  const retry = (url) => {{
+    const controller = new AbortController();
+    Promise.race([
+        fetch(url, {{ cache: "no-store", signal: controller.signal }}),
+        new Promise((_, reject) => setTimeout(() => {{ 
+          controller.abort();
+          reject();
+        }}, 500))
+      ])
       .then(() => console.log("[tower-livereload] reload..."))
       .then(() => window.location.reload())
       .catch(() => setTimeout(() => retry(url), {reload_interval}));
+  }}
 
   const main = () =>
     fetch("{long_poll}", {{ cache: "no-store" }})


### PR DESCRIPTION
When developing behind inside a [devcontainer](https://code.visualstudio.com/docs/devcontainers/containers), I noticed the fetch to the **back_up** hangs forever.  This is due to the observation that the forwarded port in vscode does not get recycled when cargo-watch restarts the process.

![image](https://github.com/leotaku/tower-livereload/assets/6287039/da00adbc-d1e6-4b5c-bfa4-8b67736e2b4b)

This PR resolves the above issue by introducing a timeout that aborts the **back_up** request after 500ms and retries the request after the specified interval.

![image](https://github.com/leotaku/tower-livereload/assets/6287039/bb4f2287-c5c9-423a-ae1f-f719b76d9561)

