### PR TITLE
Wait and retry when back-up url is available but returns HTTP error

### DIFF
--- a/assets/polling.html
+++ b/assets/polling.html
@@ -9,6 +9,7 @@
     const controller = new AbortController();
     setTimeout(() => controller.abort(), 500);
     fetch(url, {{ cache: "no-store", signal: controller.signal }})
+      .then((resp) => resp.ok ? resp : Promise.reject())
       .then(() => console.log("[tower-livereload] reload..."))
       .then(() => window.location.reload())
       .catch(() => setTimeout(() => retry(url), {reload_interval}))


### PR DESCRIPTION
This is helpful in cases where the Rust app is running behind a proxy.

Closes #12