### PR TITLE
Fix new axum version incompatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,8 +79,7 @@ that also uses those crates, such as [`hyper`], [`axum`], [`tonic`], and
 To provide LiveReload functionality, we have to inject code into HTML web
 pages. To determine whether a page is injectable, some header-based
 heuristics are used. In particular, [`Content-Type`] has to start with
-`text/html`, [`Content-Length`] must be set, and [`Content-Encoding`] must
-not be set.
+`text/html` and [`Content-Encoding`] must not be set.
 
 If LiveReload is not working for some of your pages, ensure that these
 heuristics apply to your responses. In particular, if you use middleware to
@@ -88,7 +87,6 @@ compress your HTML, ensure that the [`LiveReload`] middleware is
 applied before your compression middleware.
 
 [`Content-Type`]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Type
-[`Content-Length`]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Length
 [`Content-Encoding`]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Encoding
 
 <!-- Override internal links from README generation: -->

--- a/examples/playwright/Cargo.toml
+++ b/examples/playwright/Cargo.toml
@@ -4,6 +4,6 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-axum = { version = "0.7.7", features = ["macros"] }
+axum = { version = "0.7.9", features = ["macros"] }
 tokio = { version = "1.40.0", features = ["macros", "rt-multi-thread"] }
 tower-livereload = { path = "../.." }

--- a/src/inject.rs
+++ b/src/inject.rs
@@ -101,16 +101,19 @@ where
             });
 
         let (mut parts, body) = response.into_parts();
-        let inject = if let Some(length) = content_length {
+        if let Some(length) = content_length {
             parts
                 .headers
                 .insert(header::CONTENT_LENGTH, (length + data.remaining()).into());
-            this.data.take()
-        } else {
-            None
         };
 
-        Poll::Ready(Ok(Response::from_parts(parts, InjectBody { body, inject })))
+        Poll::Ready(Ok(Response::from_parts(
+            parts,
+            InjectBody {
+                body,
+                inject: this.data.take(),
+            },
+        )))
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -62,8 +62,7 @@
 //! To provide LiveReload functionality, we have to inject code into HTML web
 //! pages. To determine whether a page is injectable, some header-based
 //! heuristics are used. In particular, [`Content-Type`] has to start with
-//! `text/html`, [`Content-Length`] must be set, and [`Content-Encoding`] must
-//! not be set.
+//! `text/html` and [`Content-Encoding`] must not be set.
 //!
 //! If LiveReload is not working for some of your pages, ensure that these
 //! heuristics apply to your responses. In particular, if you use middleware to
@@ -71,7 +70,6 @@
 //! applied before your compression middleware.
 //!
 //! [`Content-Type`]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Type
-//! [`Content-Length`]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Length
 //! [`Content-Encoding`]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Encoding
 
 #![forbid(unsafe_code, unused_unsafe)]
@@ -197,14 +195,12 @@ impl<ReqPred, ResPred> LiveReloadLayer<ReqPred, ResPred> {
     ///
     /// Note that this predicate is applied instead of the default response
     /// predicate, which would make sure that only HTML responses are injected.
-    /// However, even with a custom predicate only responses that have a valid
-    /// [`Content-Length`] header, and no [`Content-Encoding`] header can and
-    /// will be injected.
+    /// However, even with a custom predicate only responses without a custom
+    /// encoding i.e. no [`Content-Encoding`] header can and will be injected.
     ///
     /// Also see [`predicate`] for pre-defined predicates and
     /// [`predicate::Predicate`] for how to implement your own predicates.
     ///
-    /// [`Content-Length`]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Length
     /// [`Content-Encoding`]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Encoding
     pub fn response_predicate<Body, P: Predicate<Response<Body>>>(
         self,


### PR DESCRIPTION
If I understand #19 correctly, this should cause our integration tests to fail.