### PR TITLE
Delegate source() in OverlayError's Error impl

### DIFF
--- a/src/overlay.rs
+++ b/src/overlay.rs
@@ -154,7 +154,14 @@ pub enum OverlayError<A, B> {
     B(B),
 }
 
-impl<A: std::error::Error, B: std::error::Error> std::error::Error for OverlayError<A, B> {}
+impl<A: std::error::Error, B: std::error::Error> std::error::Error for OverlayError<A, B> {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            OverlayError::A(a) => a.source(),
+            OverlayError::B(b) => b.source(),
+        }
+    }
+}
 
 impl<A: Display, B: Display> Display for OverlayError<A, B> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {


### PR DESCRIPTION
Currently, when a view is wrapped in LiveReloadLayer, it's impossible to traverse through the stack of errors, since the error type internally used by the Service doesn't implement source(). This commit fixes that.