### PR TITLE
Various non backwards compatible changes

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -149,9 +149,9 @@ impl LiveReloadLayer {
 impl<ReqPred, ResPred> LiveReloadLayer<ReqPred, ResPred> {
     /// Set a custom prefix for internal routes for the given
     /// [`LiveReloadLayer`].
-    pub fn custom_prefix<P: AsRef<str>>(self, prefix: P) -> Self {
+    pub fn custom_prefix<P: Into<String>>(self, prefix: P) -> Self {
         Self {
-            custom_prefix: Some(prefix.as_ref().to_owned()),
+            custom_prefix: Some(prefix.into()),
             ..self
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -147,15 +147,6 @@ impl LiveReloadLayer {
             reload_interval: Duration::from_secs(1),
         }
     }
-
-    /// Create a new [`LiveReloadLayer`] with a custom prefix.
-    #[deprecated(
-        since = "0.8.0",
-        note = "please use `LiveReloadLayer::new` and `custom_prefix` instead"
-    )]
-    pub fn with_custom_prefix<P: Into<String>>(prefix: P) -> Self {
-        Self::new().custom_prefix(prefix)
-    }
 }
 
 impl<ReqPred, ResPred> LiveReloadLayer<ReqPred, ResPred> {
@@ -263,12 +254,7 @@ pub struct LiveReload<S, ReqPred = Always, ResPred = ContentTypeStartsWith<&'sta
 }
 
 impl<S, ReqPred, ResPred> LiveReload<S, ReqPred, ResPred> {
-    #[deprecated(
-        since = "0.9.0",
-        note = "please use `LiveReloadLayer::new().layer(service)` instead"
-    )]
-    /// Create a new [`LiveReload`] middleware.
-    pub fn new<P: Into<String>>(
+    fn new<P: Into<String>>(
         service: S,
         reloader: Reloader,
         req_predicate: ReqPred,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -149,9 +149,9 @@ impl LiveReloadLayer {
 impl<ReqPred, ResPred> LiveReloadLayer<ReqPred, ResPred> {
     /// Set a custom prefix for internal routes for the given
     /// [`LiveReloadLayer`].
-    pub fn custom_prefix<P: Into<String>>(self, prefix: P) -> Self {
+    pub fn custom_prefix<P: AsRef<str>>(self, prefix: P) -> Self {
         Self {
-            custom_prefix: Some(prefix.into()),
+            custom_prefix: Some(prefix.as_ref().to_owned()),
             ..self
         }
     }
@@ -251,7 +251,7 @@ pub struct LiveReload<S, ReqPred = Always, ResPred = ContentTypeStartsWith<&'sta
 }
 
 impl<S, ReqPred, ResPred> LiveReload<S, ReqPred, ResPred> {
-    fn new<P: Into<String>>(
+    fn new<P: AsRef<str>>(
         service: S,
         reloader: Reloader,
         req_predicate: ReqPred,
@@ -259,7 +259,7 @@ impl<S, ReqPred, ResPred> LiveReload<S, ReqPred, ResPred> {
         reload_interval: Duration,
         prefix: P,
     ) -> Self {
-        let event_stream_path = format!("{}/event-stream", prefix.into());
+        let event_stream_path = format!("{}/event-stream", prefix.as_ref());
         let inject = InjectService::new(
             service,
             format!(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -91,7 +91,7 @@ use sse::ReloadEventsBody;
 use tokio::sync::broadcast::Sender;
 use tower::{Layer, Service};
 
-const DEFAULT_PREFIX: &str = "/tower-livereload/long-name-to-avoid-collisions";
+const DEFAULT_PREFIX: &str = "/_tower-livereload";
 
 /// Utility to send reload requests to clients.
 #[derive(Clone, Debug)]
@@ -135,9 +135,6 @@ pub struct LiveReloadLayer<ReqPred = Always, ResPred = ContentTypeStartsWith<&'s
 impl LiveReloadLayer {
     /// Create a new [`LiveReloadLayer`] with the default prefix for internal
     /// routes.
-    ///
-    /// The default prefix is deliberately long and specific to avoid any
-    /// accidental collisions with the wrapped service.
     pub fn new() -> Self {
         Self {
             custom_prefix: None,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -226,7 +226,6 @@ impl<S, ReqPred: Copy, ResPred: Copy> Layer<S> for LiveReloadLayer<ReqPred, ResP
     type Service = LiveReload<S, ReqPred, ResPred>;
 
     fn layer(&self, inner: S) -> Self::Service {
-        #[allow(deprecated)]
         LiveReload::new(
             inner,
             self.reloader.clone(),


### PR DESCRIPTION
+ Remove or make private deprecated functions
+ `AsRef<str>` instead of `Into<String>` (now only internally, public interface remains the same)
+ Shorter private asset prefix