### PR TITLE
Minimize event source creation and ensure cleanup

### DIFF
--- a/assets/sse_reload.js
+++ b/assets/sse_reload.js
@@ -1,25 +1,36 @@
 (() => {
   const inputs = document.currentScript.dataset;
+  let source;
+
+  const cleanup = () => {
+    if (source) {
+      source.close();
+      source = null;
+    }
+  };
 
   addEventListener("pageshow", () => {
-    const source = new EventSource(inputs.eventStream);
+    if (source) return;
+
+    source = new EventSource(inputs.eventStream);
+
     source.addEventListener("reload", () => {
-      source.close();
+      cleanup();
       window.location.reload();
     });
 
     const onerror = () => {
       source.removeEventListener("error", onerror);
       source.addEventListener("init", () => {
-        source.close();
+        cleanup();
         window.location.reload();
       });
     };
 
     source.addEventListener("error", onerror);
+  });
 
-    addEventListener("pagehide", () => {
-      source.removeEventListener("error", onerror)
-    });
+  addEventListener("pagehide", () => {
+    cleanup();
   });
 })();


### PR DESCRIPTION
I was finding that if I navigated back and forth between two pages with livereload injecting its JS snippet, Chrome would eventually stop loading the new page due to connection starvation. Chrome's SSE connection caching (which is done for fast back-button performance) seems far less likely to be useful in situations where livereload is used than the ability to jump around alot while debugging a site.